### PR TITLE
Fix big memory leak when relying on View#remove to cleanup

### DIFF
--- a/backbone.declarative.js
+++ b/backbone.declarative.js
@@ -34,9 +34,11 @@
     }
 
   , _unbindDeclarativeEvents: function (prop) {
-      var methods = this['_' + prop + 'Events'];
+      var cacheName = '_' + prop + 'Events';
+      var methods = this[cacheName];
       if (!methods) return;
       this.stopListening(this[prop], methods);
+      delete this[cacheName];
     }
 
   , bindModelEvents: function (modelEvents) {


### PR DESCRIPTION
Since a single/global viewMethods was previously used to store event hashes, if you were done with a view and only relied on View#remove (since #3) for cleanup rather than calling unbindXEvents manually, then even if you disposed of all of your own view references, Backbone Declarative's viewMethods variable would hold a reference to each event method which, by closure, would contain the Views themselves.

We're still keeping a reference to all the bound events/methods, but by doing it on a per-view level the garbage collector can clean everything up if no external references are kept.

All tests still pass.
