### PR TITLE
Directly apply arguments

### DIFF
--- a/backbone.declarative.js
+++ b/backbone.declarative.js
@@ -16,7 +16,7 @@
 
   Backbone.View = _View.extend({
     constructor: function () {
-      _View.apply(this, Array.prototype.slice.call(arguments));
+      _View.apply(this, arguments);
       this.bindModelEvents();
       this.bindCollectionEvents();
     }


### PR DESCRIPTION
You can directly apply the arguments object instead of coercing it into
an array. This adds a significant [speed
bump](http://jsperf.com/apply-directly-vs-apply-array), even if this is only a
constructor.
